### PR TITLE
Changed the nix package value to get it to build against nixos-unstable and 24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733212471,
-        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "lastModified": 1733261153,
+        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699963925,
-        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
+        "lastModified": 1733212471,
+        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
+        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,6 @@
 {
   inputs = {
-    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
-    #nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    # nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
@@ -73,7 +71,7 @@
           hardware.deviceTree.name = "rockchip/rk3568-odroid-m1.dtb";
 
           # Enable nix flakes
-          nix.package = pkgs.nixFlakes;
+          nix.package = pkgs.nix;
           nix.extraOptions = ''
             experimental-features = nix-command flakes
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -1,74 +1,21 @@
 {
+  description = "Nix image for odroid M1";
   inputs = {
-    # nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
   };
-
-  outputs = {nixpkgs, ...}: let
-    system = "x86_64-linux";
-    pkgs = import nixpkgs {
-      inherit system;
-    };
-    lib = nixpkgs.lib;
-  in rec {
-    devShell.${system} = pkgs.mkShell {
-      buildInputs = with pkgs; [
-        rsync
-        zstd
-        git
-      ];
-    };
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
-
-    nixosConfigurations.m1 = lib.nixosSystem {
-      system = "aarch64-linux";
-
+  outputs = { self, nixpkgs }: rec {
+    nixosConfigurations.m1 = nixpkgs.lib.nixosSystem {
       modules = [
-        ({
-          pkgs,
-          config,
-          ...
-        }: {
-          imports = [
-            "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
-            "${fetchTarball {url="https://github.com/KhashayarDanesh/nixos-hardware/tarball/master"; sha256="11698l6r6p0jajd0c2rda0ipi54yi26wrj32a006256axvzz6wqh";}}/hardkernel/odroid-m1"
-            ./sdimageconfiguration.nix
-          ];
-
-          sdImage = {
-            compressImage = false;
-            populateFirmwareCommands = let
-              configTxt = pkgs.writeText "README" ''
-                Nothing to see here. This empty partition is here because I don't know how to turn its creation off.
-              '';
-            in ''
-              cp ${configTxt} firmware/README
-            '';
-            populateRootCommands = ''
-              ${config.boot.loader.kboot-conf.populateCmd} -c ${config.system.build.toplevel} -d ./files/kboot.conf
-            '';
-          };
-
-          # Enable nix flakes
-          nix.package = pkgs.nix;
-          nix.extraOptions = ''
-            experimental-features = nix-command flakes
-          '';
-          environment.systemPackages = [
-            pkgs.git #gotta have git
-          ];
-
-          services.openssh = {
-            enable = true;
-            settings.PermitRootLogin = "yes";
-          };
-          users.extraUsers.root.initialPassword = lib.mkForce "odroid";
-        })
+        "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+        "${fetchTarball {url="https://github.com/KhashayarDanesh/nixos-hardware/tarball/master"; sha256="11698l6r6p0jajd0c2rda0ipi54yi26wrj32a006256axvzz6wqh";}}/hardkernel/odroid-m1"
+        ./sdimageconfiguration.nix
+        {
+          nixpkgs.config.allowUnsupportedSystem = true;
+          nixpkgs.hostPlatform.system = "aarch64-linux";
+          nixpkgs.buildPlatform.system = "x86_64-linux"; #If you build on x86 other wise changes this.     
+        }
       ];
     };
-
-    images = {
-      m1 = nixosConfigurations.m1.config.system.build.sdImage;
-    };
+    images.m1 = nixosConfigurations.m1.config.system.build.sdImage;
   };
 }

--- a/sdimageconfiguration.nix
+++ b/sdimageconfiguration.nix
@@ -2,11 +2,6 @@
 {
   system.stateVersion = lib.mkDefault "24.11";
 
-  imports = [
-    #"${fetchTarball "https://github.com/KhashayarDanesh/nixos-hardware/tarball/master"}/hardkernel/odroid-m1"
-    "${fetchTarball {url="https://github.com/KhashayarDanesh/nixos-hardware/tarball/master"; sha256="11698l6r6p0jajd0c2rda0ipi54yi26wrj32a006256axvzz6wqh";}}/hardkernel/odroid-m1/"
-  ];
-
   nixpkgs.hostPlatform.system = "aarch64-linux";
 
   services.openssh = {

--- a/sdimageconfiguration.nix
+++ b/sdimageconfiguration.nix
@@ -1,0 +1,22 @@
+{ config, pkgs, lib, ... }:
+{
+  system.stateVersion = lib.mkDefault "24.11";
+
+  imports = [
+    #"${fetchTarball "https://github.com/KhashayarDanesh/nixos-hardware/tarball/master"}/hardkernel/odroid-m1"
+    "${fetchTarball {url="https://github.com/KhashayarDanesh/nixos-hardware/tarball/master"; sha256="11698l6r6p0jajd0c2rda0ipi54yi26wrj32a006256axvzz6wqh";}}/hardkernel/odroid-m1/"
+  ];
+
+  nixpkgs.hostPlatform.system = "aarch64-linux";
+
+  services.openssh = {
+    enable = true;
+    settings.PermitRootLogin = "yes";
+  };
+
+  users.extraUsers.root.initialPassword = lib.mkForce "odroid";
+  users.users.root.openssh.authorizedKeys.keys =  [ 
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGViv0xBt1nxIcFIL2TG2E7TPY6OVMZrtAY+WwVbBIbx khashayar@tangerine.local"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOlKj4SAmCOccg09PDN15uPsF5PqbL/Cvepjuw28RKZe khashayar@deepthought.local" 
+    ];
+}


### PR DESCRIPTION
Hello, 

I was trying to build my own image today using the instructions and the following error happened: 

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bf744fe90419885eefced41b3e5ae442d732712d?narHash=sha256-LE7OV/SwkIBsCpAlIPiFhch/J%2BjBDGEZjNfdnzCnCrY%3D' (2023-11-14)
  → 'github:nixos/nixpkgs/b681065d0919f7eb5309a93cea2cfa84dec9aa88?narHash=sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek%3D' (2024-12-03)
warning: Git tree '/home/khashayar/projects/nixos-on-odroid-m1' is dirty
evaluation warning: system.stateVersion is not set, defaulting to 24.11. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'nixos-sd-image-24.11.20241203.b681065-aarch64-linux.img'
         whose name attribute is located at /nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/pkgs/stdenv/generic/make-derivation.nix:336:7

       … while evaluating attribute 'buildCommand' of derivation 'nixos-sd-image-24.11.20241203.b681065-aarch64-linux.img'
         at /nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/installer/sd-card/sd-image.nix:191:7:
          190|
          191|       buildCommand = ''
             |       ^
          192|         mkdir -p $out/nix-support $out/sd-image

       … while evaluating the option `sdImage.populateRootCommands':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/installer/sd-card/sd-image-aarch64.nix':

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `assertions':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/system/boot/systemd.nix':

       … while evaluating the option `systemd.services':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/services/logging/logrotate.nix':

       … while evaluating the option `services.logrotate.enable':

       … while evaluating the option `users.groups':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/config/resolvconf.nix':

       … while evaluating the option `networking.resolvconf.enable':

       … while evaluating the option `environment.etc':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/services/networking/ssh/sshd.nix':

       … while evaluating the option `users.users':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/services/system/nix-daemon.nix':

       … while evaluating the option `nix.nrBuildUsers':

       … while evaluating the option `nix.settings':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/nixos/modules/services/system/nix-daemon.nix':

       … while evaluating the option `nix.package':

       … while evaluating definitions from `/nix/store/w66xaybnxjf5zhxapxs3pd3zp7gxk9dw-source/flake.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: 'nixFlakes' has been renamed to/replaced by 'nixVersions.stable'
```

As it turns out, they've changed the name of that package. I reflected the change in the flake.nix file and not this image could be built against nixos-24.11 and 25.05(unstable)!

The image is untested though, I'm going through testing today and will make more changes if necessary -:) 